### PR TITLE
Enable GCP Cloud Build to read from substitution variables on pantheon

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,9 +29,9 @@ app.use(express.urlencoded());
 app.use('/static', express.static('public'));
 
 // Load API keys.
-if (process.env.NODE_ENV !== 'production') {
-  require('dotenv').config();
-} else {
+require('dotenv').config();
+
+if (process.env.NODE_ENV === 'production') {
   console.log(PROD_WARNING_MESSAGE);
 }
 

--- a/app.js
+++ b/app.js
@@ -31,6 +31,7 @@ app.use('/static', express.static('public'));
 // Load API keys.
 require('dotenv').config();
 
+// Show production warning message.
 if (process.env.NODE_ENV === 'production') {
   console.log(PROD_WARNING_MESSAGE);
 }

--- a/gcp/clouddeploy.yaml
+++ b/gcp/clouddeploy.yaml
@@ -5,6 +5,11 @@ steps:
 - name: node
   entrypoint: npm
   args: ['test']
+- name: node
+  entrypoint: npm
+  args: ["run", "create-env"]
+  env:
+    - 'MAPS_KEY=${_MAPS_PROD_KEY}'
 - name: "gcr.io/cloud-builders/gcloud"  
   args: ["app", "deploy"]
   timeout: 1800s

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Skeleton app for Node.js based STEP capstone project. ",
   "main": "index.js",
   "scripts": {
+    "create-env": "printenv > .env",
     "test": "./node_modules/.bin/mocha --exit",
     "start": "NODE_ENV=production node app.js",
     "dev": "NODE_ENV=development node app.js"


### PR DESCRIPTION
This PR enables GCP Cloud Build to read from GCP pantheon substitution variables (configed via cloud.google.com), which contains API keys. 

Follow-up PR will add support for passport.js related API keys. I will reach out to @danielabreo for more information on this. 

Close #36 