### PR TITLE
Add passort.js API key injection in GCP Cloud Build config

### DIFF
--- a/gcp/cloudbuild.yaml
+++ b/gcp/cloudbuild.yaml
@@ -4,4 +4,11 @@ steps:
   args: ['install']
 - name: node
   entrypoint: npm
+  args: ["run", "create-env"]
+  env:
+    - 'MAPS_KEY=${_MAPS_PROD_KEY}'
+    - 'PASSPORT_CLIENT_ID=${_PASSPORT_PROD_CLIENT_ID}'
+    - 'PASSPORT_CLIENT_SECRET=${_PASSPORT_PROD_CLIENT_SECRET}'
+- name: node
+  entrypoint: npm
   args: ['test']

--- a/gcp/clouddeploy.yaml
+++ b/gcp/clouddeploy.yaml
@@ -4,12 +4,14 @@ steps:
   args: ['install']
 - name: node
   entrypoint: npm
-  args: ['test']
-- name: node
-  entrypoint: npm
   args: ["run", "create-env"]
   env:
     - 'MAPS_KEY=${_MAPS_PROD_KEY}'
+    - 'PASSPORT_CLIENT_ID=${_PASSPORT_PROD_CLIENT_ID}'
+    - 'PASSPORT_CLIENT_SECRET=${_PASSPORT_PROD_CLIENT_SECRET}'
+- name: node
+  entrypoint: npm
+  args: ['test']
 - name: "gcr.io/cloud-builders/gcloud"  
   args: ["app", "deploy"]
   timeout: 1800s


### PR DESCRIPTION
This PR enables GCP Cloud Build to inject passort.js API key on build-time from pantheon (for both unit test trigger and deployment trigger), which will resolve red build check issue in PR #55 .