### PR TITLE
Add member endpoints

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,6 +88,8 @@ app.get(
 );
 app.post('/data/acceptedcategories/organization/:id', data.acceptedCategoriesOrganizationPost);
 app.get('/data/categories', data.categoriesGet);
+app.get('/data/member', data.member);
+app.get('/data/member/organization/:id', data.organizationMemberGet);
 
 http.createServer(app).listen(app.get('port'), function () {
   console.log('Express server listening on port ' + app.get('port'));

--- a/routes/data.js
+++ b/routes/data.js
@@ -114,3 +114,40 @@ exports.categoriesGet = async function (req, res) {
   });
   res.send(categories);
 };
+
+exports.member = async function (req, res) {
+  const memberData = req.user;
+  const userData = {
+    authenticationID: memberData.id,
+    name: memberData.displayName,
+  };
+  const memberSnapshot = await firestore
+    .collection(resolveCollectionName('Members'))
+    .where("authenticationID", "==", memberData.id);
+
+  memberSnapshot.get().then(function (doc) {
+    if (doc.docs[0]) {
+      res.send(doc.docs[0].id);
+    } else {
+      firestore
+        .collection(resolveCollectionName('Members'))
+        .doc().set(userData)
+        .then(memberSnapshot.get().then(function (doc) {
+          res.send(doc.docs[0].id);
+        }));
+    }
+  });
+}
+
+exports.organizationMemberGet = async function (req, res) {
+  const organizationReference = firestore
+    .collection(resolveCollectionName('Organizations'))
+    .doc(req.params.id);
+  
+  const member = await firestore
+    .collection(resolveCollectionName('MemberAssignments'))
+    .where('organization', '==', organizationReference)
+    .get();
+
+  res.send(member.docs[0]);
+}

--- a/routes/data.js
+++ b/routes/data.js
@@ -123,7 +123,7 @@ exports.member = async function (req, res) {
   };
   const memberSnapshot = await firestore
     .collection(resolveCollectionName('Members'))
-    .where("authenticationID", "==", memberData.id);
+    .where('authenticationID', '==', memberData.id);
 
   memberSnapshot.get().then(function (doc) {
     if (doc.docs[0]) {
@@ -131,23 +131,30 @@ exports.member = async function (req, res) {
     } else {
       firestore
         .collection(resolveCollectionName('Members'))
-        .doc().set(userData)
-        .then(memberSnapshot.get().then(function (doc) {
-          res.send(doc.docs[0].id);
-        }));
+        .doc()
+        .set(userData)
+        .then(
+          memberSnapshot.get().then(function (doc) {
+            res.send(doc.docs[0].id);
+          })
+        );
     }
   });
-}
+};
 
 exports.organizationMemberGet = async function (req, res) {
   const organizationReference = firestore
     .collection(resolveCollectionName('Organizations'))
     .doc(req.params.id);
-  
-  const member = await firestore
+
+  const memberAssignments = await firestore
     .collection(resolveCollectionName('MemberAssignments'))
     .where('organization', '==', organizationReference)
     .get();
 
-  res.send(member.docs[0]);
-}
+  const memberReference = await memberAssignments.docs[0].data().member._path.segments;
+
+  const memberInfo = await firestore.collection(memberReference[0]).doc(memberReference[1]).get();
+
+  res.send(memberInfo.data());
+};

--- a/test/test-data.js
+++ b/test/test-data.js
@@ -186,26 +186,3 @@ it('POST Request /data/acceptedcategories/organization/:id : add new AcceptedCat
     }
   );
 });
-
-// it('something', function (done) {
-//   request.headers['user'] = {
-//       'id': '107880125086980314459',
-//       'displayName': 'Dan',
-//   };
-//   request(
-//     // {
-//     //   headers: {
-//     //     'user': {
-//     //       'id': '107880125086980314459',
-//     //       'displayName': 'Dan',
-//     //     }
-//     //   },
-//     //   url: `http://localhost:3000/data/member`,
-//     // },
-//     `http://localhost:3000/data/member`,
-//     function (error, response, body) {
-//       expect(response.statusCode).to.equal(200);
-//       done();
-//     }
-//   );
-// });

--- a/test/test-data.js
+++ b/test/test-data.js
@@ -186,3 +186,26 @@ it('POST Request /data/acceptedcategories/organization/:id : add new AcceptedCat
     }
   );
 });
+
+// it('something', function (done) {
+//   request.headers['user'] = {
+//       'id': '107880125086980314459',
+//       'displayName': 'Dan',
+//   };
+//   request(
+//     // {
+//     //   headers: {
+//     //     'user': {
+//     //       'id': '107880125086980314459',
+//     //       'displayName': 'Dan',
+//     //     }
+//     //   },
+//     //   url: `http://localhost:3000/data/member`,
+//     // },
+//     `http://localhost:3000/data/member`,
+//     function (error, response, body) {
+//       expect(response.statusCode).to.equal(200);
+//       done();
+//     }
+//   );
+// });


### PR DESCRIPTION
Note: testing for these endpoints was attempted, but unsuccessful due to the library we are using to test.

Added 2 API's for getting member information:

1. `/data/member` If a member exists, return its database ID. If the member does not exist, create a new member and return its google ID.

2. `/data/member/organization/:id` Return Member that is assigned to Organization.