### PR TITLE
Autocomplete bug fix

### DIFF
--- a/public/js/discover/autocomplete.js
+++ b/public/js/discover/autocomplete.js
@@ -15,7 +15,6 @@ const autocompleteOptionTemplate = `
  * @param {string} input The text from the search box.
  */
 window.showAutocompleteOptions = function (input) {
-  console.log('inputted', input);
   if (input === '') {
     document.getElementById('autocomplete-list').innerHTML = '';
     return;

--- a/public/js/discover/autocomplete.js
+++ b/public/js/discover/autocomplete.js
@@ -1,6 +1,6 @@
 /* global Trie Handlebars categories */
 
-const categoryTrie = new Trie(parsedCategories);
+const categoryTrie = new Trie(Object.keys(categories));
 
 const autocompleteOptionTemplate = `
       {{#each matches}}
@@ -15,6 +15,7 @@ const autocompleteOptionTemplate = `
  * @param {string} input The text from the search box.
  */
 window.showAutocompleteOptions = function (input) {
+  console.log("inputted", input)
   if (input === '') {
     document.getElementById('autocomplete-list').innerHTML = '';
     return;

--- a/public/js/discover/autocomplete.js
+++ b/public/js/discover/autocomplete.js
@@ -15,7 +15,7 @@ const autocompleteOptionTemplate = `
  * @param {string} input The text from the search box.
  */
 window.showAutocompleteOptions = function (input) {
-  console.log("inputted", input)
+  console.log('inputted', input);
   if (input === '') {
     document.getElementById('autocomplete-list').innerHTML = '';
     return;

--- a/public/js/discover/autocomplete.js
+++ b/public/js/discover/autocomplete.js
@@ -1,6 +1,6 @@
 /* global Trie Handlebars categories */
 
-const categoryTrie = new Trie(categories);
+const categoryTrie = new Trie(parsedCategories);
 
 const autocompleteOptionTemplate = `
       {{#each matches}}

--- a/public/js/discover/discover.js
+++ b/public/js/discover/discover.js
@@ -1,6 +1,8 @@
 import {createOrganizationCards, selectCard} from './searchList.js';
 import {initMap, createMarkers, selectMarker, removeAllMarkers} from './maps.js';
 
+/* global categories */
+
 /**
  * When the page loads, fetches initial organization data and render it
  * in cards on the list.

--- a/public/js/discover/discover.js
+++ b/public/js/discover/discover.js
@@ -40,13 +40,13 @@ function updateSearchResults() {
   document.getElementById('search-list').innerHTML = '';
   removeAllMarkers();
 
-  let parsedFilter = document.getElementById('autocomplete-input').value;
-  if (parsedFilter === '') parsedFilter = 'all';
+  let filter = document.getElementById('autocomplete-input').value;
+  if (filter === '') filter = 'all';
 
-  const filter = categories[parsedFilter];
+  const unparsedFilter = categories[filter];
 
   // Requery and repopulate page data.
-  fetch('/discover/' + filter)
+  fetch('/discover/' + unparsedFilter)
     .then((data) => data.json())
     .then((organizations) => {
       createOrganizationCards(organizations);

--- a/public/js/discover/discover.js
+++ b/public/js/discover/discover.js
@@ -34,11 +34,14 @@ function setPageEventListeners() {
  * Requeries for organization data and refreshes page data.
  */
 function updateSearchResults() {
+  document.getElementById('autocomplete-list').innerHTML = '';
   document.getElementById('search-list').innerHTML = '';
   removeAllMarkers();
 
-  let filter = document.getElementById('autocomplete-input').value;
-  if (filter === '') filter = 'all';
+  let parsedFilter = document.getElementById('autocomplete-input').value;
+  if (parsedFilter === '') parsedFilter = 'all';
+
+  const filter = categories[parsedFilter];
 
   // Requery and repopulate page data.
   fetch('/discover/' + filter)

--- a/public/js/discover/trie.js
+++ b/public/js/discover/trie.js
@@ -47,7 +47,7 @@ class Trie {
 
     // Iterate down the tree for each character in the word.
     for (let level = 0; level < word.length; level++) {
-      const index = word.charCodeAt(level) - 97;
+      const index = word.charAt(level) === ' ' ? 26 : word.charCodeAt(level) - 97;
 
       // Insert the node for that prefix into the trie if it doesn't exist.
       if (!currentNode.children[index]) {

--- a/routes/discover.js
+++ b/routes/discover.js
@@ -30,15 +30,13 @@ exports.getOrganizations = async function (req, res) {
  * @return {array} The categories parsed into a human-readable format.
  */
 function parseCategories(categories) {
-  const parsed = [];
+  const parsed = {};
   for (let category of categories) {
     // Replaces special characters with spaces.
-    category = category.replace(/[^a-zA-Z0-9]/g, ' ');
+    let parsedCategory = category.replace(/[^a-zA-Z0-9]/g, ' ');
 
-    // Capitalize all categories
-    category = category.charAt(0).toUpperCase() + category.slice(1);
-
-    parsed.push(category);
+    // parsed[category] = parsedCategory;
+    parsed[parsedCategory] = category;
   }
   return parsed;
 }

--- a/routes/discover.js
+++ b/routes/discover.js
@@ -31,9 +31,9 @@ exports.getOrganizations = async function (req, res) {
  */
 function parseCategories(categories) {
   const parsed = {};
-  for (let category of categories) {
+  for (const category of categories) {
     // Replaces special characters with spaces.
-    let parsedCategory = category.replace(/[^a-zA-Z0-9]/g, ' ');
+    const parsedCategory = category.replace(/[^a-zA-Z0-9]/g, ' ');
 
     // parsed[category] = parsedCategory;
     parsed[parsedCategory] = category;

--- a/routes/discover.js
+++ b/routes/discover.js
@@ -27,15 +27,13 @@ exports.getOrganizations = async function (req, res) {
 /**
  * Parses the categories into a human-readable format for the discover page.
  * @param {array} categories The categories as saved in the database.
- * @return {array} The categories parsed into a human-readable format.
+ * @return {JSON} An object matching parsed category named to unparsed category names.
  */
 function parseCategories(categories) {
   const parsed = {};
   for (const category of categories) {
     // Replaces special characters with spaces.
     const parsedCategory = category.replace(/[^a-zA-Z0-9]/g, ' ');
-
-    // parsed[category] = parsedCategory;
     parsed[parsedCategory] = category;
   }
   return parsed;

--- a/views/discover.handlebars
+++ b/views/discover.handlebars
@@ -3,6 +3,7 @@
 
 <script>
   const categories = JSON.parse('{{{json categories}}}');
+  const parsedCategories = Object.keys(categories);
 </script>
 
 <script async defer src="https://maps.googleapis.com/maps/api/js?key={{MAPS_KEY}}"></script>

--- a/views/discover.handlebars
+++ b/views/discover.handlebars
@@ -3,7 +3,6 @@
 
 <script>
   const categories = JSON.parse('{{{json categories}}}');
-  const parsedCategories = Object.keys(categories);
 </script>
 
 <script async defer src="https://maps.googleapis.com/maps/api/js?key={{MAPS_KEY}}"></script>


### PR DESCRIPTION
Before, category names were being parsed (no special characters) before being passed to the front-end for search filtering. They, however, were not being unparsed before being used to query the database.

This PR uses a JSON object that matches parsed names to unparsed names to solve this issue. Unparsed names are retrieved from the JSON before querying.