### PR TITLE
Invalid coordinates bug fix

### DIFF
--- a/public/js/discover/maps.js
+++ b/public/js/discover/maps.js
@@ -31,45 +31,44 @@ export function initMap() {
  * @param {JSON} data A json containing organzation data to create markers for.
  */
 export function createMarkers(data) {
-  data.forEach((organization) => {
-    // If no coordinates, skip to the next organization.
-    if (!organization.coordinates) return;
+  data
+    .filter((organization) => !!organization.coordinates)
+    .forEach((organization) => {
+      // Create the markers and attach to the map.
+      const marker = new google.maps.Marker({
+        position: organization.coordinates,
+        map: map,
+        title: organization.name,
+        id: organization.id,
+      });
 
-    // Create the markers and attach to the map.
-    const marker = new google.maps.Marker({
-      position: organization.coordinates,
-      map: map,
-      title: organization.name,
-      id: organization.id,
+      // Create the marker info window.
+      const markerWindow = new google.maps.InfoWindow({
+        content: organization.name,
+      });
+
+      // Select a marker and dispatch an event when a marker is hovered on/off.
+      const mapContainer = document.getElementById('map');
+
+      google.maps.event.addListener(marker, 'mouseover', function () {
+        selectMarker(marker.id);
+        mapContainer.dispatchEvent(
+          new CustomEvent('markerChange', {bubbles: true, detail: marker.id})
+        );
+      });
+
+      google.maps.event.addListener(marker, 'mouseout', function () {
+        selectMarker(null);
+        mapContainer.dispatchEvent(new CustomEvent('markerChange', {bubbles: true, detail: null}));
+      });
+
+      bounds.extend(marker.getPosition());
+      map.fitBounds(bounds);
+      markers.push({
+        marker: marker,
+        markerWindow: markerWindow,
+      });
     });
-
-    // Create the marker info window.
-    const markerWindow = new google.maps.InfoWindow({
-      content: organization.name,
-    });
-
-    // Select a marker and dispatch an event when a marker is hovered on/off.
-    const mapContainer = document.getElementById('map');
-
-    google.maps.event.addListener(marker, 'mouseover', function () {
-      selectMarker(marker.id);
-      mapContainer.dispatchEvent(
-        new CustomEvent('markerChange', {bubbles: true, detail: marker.id})
-      );
-    });
-
-    google.maps.event.addListener(marker, 'mouseout', function () {
-      selectMarker(null);
-      mapContainer.dispatchEvent(new CustomEvent('markerChange', {bubbles: true, detail: null}));
-    });
-
-    bounds.extend(marker.getPosition());
-    map.fitBounds(bounds);
-    markers.push({
-      marker: marker,
-      markerWindow: markerWindow,
-    });
-  });
 }
 
 /**

--- a/public/js/discover/maps.js
+++ b/public/js/discover/maps.js
@@ -32,6 +32,9 @@ export function initMap() {
  */
 export function createMarkers(data) {
   data.forEach((organization) => {
+    // If no coordinates, skip to the next organization.
+    if (!organization.coordinates) return;
+
     // Create the markers and attach to the map.
     const marker = new google.maps.Marker({
       position: organization.coordinates,


### PR DESCRIPTION
If there is a problem with a PlaceID and coordinates can't be set, skip making that organization's map marker.

Previously, there was no check for this, and the Google maps code would throw an error for `organization.coordinates` being undefined. Because of this error stopping code execution, all following markers would not be created.