### PR TITLE
Fix Phone Number Type Bug

### DIFF
--- a/public/js/discover/searchList.js
+++ b/public/js/discover/searchList.js
@@ -86,7 +86,7 @@ export function selectCard(id = null, scroll = false) {
 
 /**
  * Formats a raw phone number into a +# (###) ### - #### format.
- * @param {integer} number The phone number unformatted.
+ * @param {number} number The phone number unformatted.
  * @return {string} The formatted phone number.
  */
 function formatPhoneNumber(number) {

--- a/public/js/discover/searchList.js
+++ b/public/js/discover/searchList.js
@@ -86,11 +86,11 @@ export function selectCard(id = null, scroll = false) {
 
 /**
  * Formats a raw phone number into a +# (###) ### - #### format.
- * @param {string} number The phone number unformatted.
+ * @param {integer} number The phone number unformatted.
  * @return {string} The formatted phone number.
  */
 function formatPhoneNumber(number) {
-  const regexMatch = number.match(/^(\d{3})(\d{3})(\d{4})$/);
+  const regexMatch = number.toString().match(/^(\d{3})(\d{3})(\d{4})$/);
   if (regexMatch) {
     return `(${regexMatch[1]}) ${regexMatch[2]}-${regexMatch[3]}`;
   }


### PR DESCRIPTION
Since phone numbers should be stored as numbers in the database, I updated the format method to convert the phone number to a string before doing regex parsing.

Phone numbers were accidentally stored as strings in the dev database, making this bug unchecked in the last PR. 